### PR TITLE
chore(ci): remove unused orb definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ executors:
           NPM_CONFIG_PREFIX: "~/.npm-global"
     working_directory: ~/repo
 
-orbs:
-  helix-post-deploy: adobe/helix-post-deploy@1.4.0
-
 commands:
   setup:
     steps:


### PR DESCRIPTION
This orb is no longer referenced in the CircleCI config.
