### PR TITLE
Tell ESLint to ignore dist

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 .vscode/*
 coverage/*
 template/*
-dist/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .vscode/*
 coverage/*
 template/*
+dist/*

--- a/template/dot-eslintignore
+++ b/template/dot-eslintignore
@@ -1,2 +1,3 @@
 .vscode/*
 coverage/*
+dist/*


### PR DESCRIPTION
First commit reverted, as it referred to the template itself, not the generated service.