### PR TITLE
fix: missing dot-nycrc.json

### DIFF
--- a/template/dot-nycrc.json
+++ b/template/dot-nycrc.json
@@ -1,0 +1,10 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "check-coverage": true,
+  "lines": 100,
+  "branches": 100,
+  "statements": 100
+}


### PR DESCRIPTION
Had an issue bootstrapping a new service, had to add `dot-nycrc.json` to the templates directory to fix.

See #479. 